### PR TITLE
dilute1 script

### DIFF
--- a/scripts/dillute1.ts
+++ b/scripts/dillute1.ts
@@ -1,0 +1,27 @@
+
+
+import { getContractFactory } from "@nomicfoundation/hardhat-ethers/types";
+import { ClaimContract, ClaimContract__factory } from "../typechain-types";
+import { ethers } from "hardhat";
+
+async function executeDilute1() {
+
+
+    const signer = await ethers.provider.getSigner();
+
+    console.log("using signer address: ", await signer.getAddress());
+
+
+    const contractaddress = "0xe0E6787A55049A90aAa4335D0Ff14fAD26B8e88e";
+
+    
+    const contract = ClaimContract__factory.connect(contractaddress, signer);
+
+
+    await  contract.dilute1();
+
+    
+}
+
+
+executeDilute1();


### PR DESCRIPTION
This pull request adds a new script to execute the `dilute1` function on a smart contract. The script connects to the contract using a specified address and a signer from the Hardhat ethers provider.

* Added a new script `scripts/dillute1.ts` to execute the `dilute1` function on the `ClaimContract` smart contract.